### PR TITLE
Change http to https

### DIFF
--- a/resources/public-rpc-endpoints/xdai-metamask.md
+++ b/resources/public-rpc-endpoints/xdai-metamask.md
@@ -12,7 +12,7 @@ To get started connecting to Pocket's infrastructure for xDAI, do the following:
 
 1. Click on the Networks drop-down menu, then press Custom RPC
 2. Under the Network Name field, write **Gnosis Pocket Portal**
-3. Within the New RPC URL field, copy and paste this endpoint URL `http://gnosischain-rpc.gateway.pokt.network/`
+3. Within the New RPC URL field, copy and paste this endpoint URL `https://gnosischain-rpc.gateway.pokt.network/`
 4. Put the hexadecimal **0x64** in the ChainID field
 5. Write **XDAI** as the Symbol
 6. Add `https://blockscout.com/poa/xdai` as the Block Explorer URL


### PR DESCRIPTION
Only the HTTPS version of the public Gnosis RPC endpoint is working at this time.