### PR TITLE
update docs for nodege sign account command

### DIFF
--- a/paths/governor/claim-your-vote/node-runner-path.md
+++ b/paths/governor/claim-your-vote/node-runner-path.md
@@ -11,7 +11,7 @@ Greetings aspiring Node Runner, we have heard your call to join us in the battle
 [Stake your node](../../node-runner/#stake-the-validator) successfully in Pocket testnet or mainnet.
 
 {% hint style="info" %}
-To verify that you own the account, you must sign a message using the following CLI command, removing the `<>` and keeping the `""`
+To verify that you own the account, you must sign a message using the following CLI command, removing the `<>` and the `""`
 
 ```
 pocket accounts sign <account address> "account address"


### PR DESCRIPTION
I tried the command with "account address" as a message but got error
using my wallet address without <> AND "" worked
![image](https://user-images.githubusercontent.com/17274326/165251251-3b0ace3b-60e6-4be3-ad11-79cd1ddec6fa.png)
