### PR TITLE
Fix links to SDK repositories

### DIFF
--- a/content/integrate/sdk/_index.md
+++ b/content/integrate/sdk/_index.md
@@ -10,5 +10,5 @@ description: A list of SDKs for interacting with Pocket.
 Here are some SDKs for interacting with Pocket:
 
 * **[PocketJS](https://github.com/pokt-foundation/pocket-js)** - JavaScript client SDK for interacting with Pocket Network.
-* **[pocket-go](https://github.com/pokt-foundation/pypocket)** - Python client SDK for interacting with Pocket Network.
-* **[pypocket](https://github.com/pokt-foundation/pypocket)** - Go client SDK for interacting with Pocket Network.
+* **[pypocket](https://github.com/pokt-foundation/pypocket)** - Python client SDK for interacting with Pocket Network.
+* **[pocket-go](https://github.com/pokt-foundation/pocket-go)** - Go client SDK for interacting with Pocket Network.


### PR DESCRIPTION
SDKs names were mixed up, the link to `pocket-go` lead to `pypocket`.