### PR TITLE
Automate population of protocol parameters

### DIFF
--- a/content/learn/protocol-parameters.md
+++ b/content/learn/protocol-parameters.md
@@ -11,6 +11,76 @@ description: List of all on-chain and relevant off-chain parameters that power P
 
 This page contains a listing of all the on-chain parameters for Pocket Network and their current values, as well as some relevant off-chain parameters.
 
+These parameters are sorted by module. You can find a description of each parameter by clicking on the parameter name.
+
+
+## Parameter values
+
+**Application Module** ([details](#application-module))
+|Parameter|Value|
+|---|---|
+|[ApplicationStakeMinimum](#applicationstakeminimum)|{{< get-param "application/ApplicationStakeMinimum" >}}|
+|[AppUnstakingTime](#appunstakingtime)|{{< get-param "application/AppUnstakingTime" >}}| 
+|[BaseRelaysPerPOKT](#baserelaysperpokt)|{{< get-param "application/BaseRelaysPerPOKT" >}}|
+|[MaxApplications](#maxapplications)|{{< get-param "application/MaxApplications" >}}|
+|[MaximumChains](#maximumchains)|{{< get-param "application/MaximumChains" >}}|
+|[ParticipationRateOn](#participationrateon)|{{< get-param "application/ParticipationRateOn" >}}|
+|[StabilityAdjustment](#stabilityadjustment)|{{< get-param "application/StabilityAdjustment" >}}|
+
+**PoS (Node) Module** ([details](#pos-node-module))
+|Parameter|Value|
+|---|---|
+|[BlocksPerSession](#blockspersession)|{{< get-param "pos/BlocksPerSession" >}}|
+|[DAOAllocation](#daoallocation)|{{< get-param "pos/DAOAllocation" >}}|
+|[DowntimeJailDuration](#downtimejailduration)|{{< get-param "pos/DowntimeJailDuration" >}}|
+|[MaxEvidenceAge](#maxevidenceage)|{{< get-param "pos/MaxEvidenceAge" >}}|
+|[MaximumChains](#maximumchains)|{{< get-param "pos/MaximumChains" >}}|
+|[MaxJailedBlocks](#maxjailedblocks)|{{< get-param "pos/MaxJailedBlocks" >}}|
+|[MaxValidators](#maxvalidators)|{{< get-param "pos/MaxValidators" >}}|
+|[MinSignedPerWindow](#minsignedperwindow)|{{< get-param "pos/MinSignedPerWindow" >}}|
+|[ProposerPercentage](#proposerpercentage)|{{< get-param  "pos/ProposerPercentage" >}}|
+|[RelaysToTokensMultiplier](#relaystotokensmultiplier)|{{< get-param "pos/RelaysToTokensMultiplier" >}}|
+|[ServicerStakeFloorMultiplier](#servicerstakefloormultiplier)|{{< get-param "pos/ServicerStakeFloorMultiplier" >}}|
+|[ServicerStakeFloorMultiplierExponent](#servicerstakefloormultiplierexponent)|{{< get-param "pos/ServicerStakeFloorMultiplierExponent" >}}|
+|[ServicerStakeWeightCeiling](#servicerstakeweightceiling)|{{< get-param "pos/ServicerStakeWeightCeiling" >}}|
+|[ServicerStakeWeightMultiplier](#servicerstakeweightmultiplier)|{{< get-param "pos/ServicerStakeWeightMultiplier" >}}|
+|[SignedBlocksWindow](#signedblockswindow)|{{< get-param "pos/SignedBlocksWindow" >}}|
+|[SlashFractionDoubleSign](#slashfractiondoublesign)|{{< get-param "pos/SlashFractionDoubleSign" >}}|
+|[SlashFractionDowntime](#slashfractiondowntime)|{{< get-param "pos/SlashFractionDowntime" >}}|
+|[StakeDenom](#stakedenom)|{{< get-param "pos/StakeDenom" >}}|
+|[StakeMinimum](#stakeminimum)|{{< get-param "pos/StakeMinimum" >}}|
+|[UnstakingTime](#unstakingtime)|{{< get-param "pos/UnstakingTime" >}}|
+
+**Pocket Core Module** ([details](#pocket-core-module))
+|Parameter|Value|
+|---|---|
+|[ClaimExpiration](#claimexpiration)|{{< get-param "pocketcore/ClaimExpiration" >}}|
+|[ClaimSubmissionWindow](#claimsubmissionwindow)|{{< get-param "pocketcore/ClaimSubmissionWindow" >}}|
+|[MinimumNumberOfProofs](#minimumnumberofproofs)|{{< get-param "pocketcore/MinimumNumberOfProofs" >}}|
+|[ReplayAttackBurnMultiplier](#replayattackburnmultiplier)|{{< get-param "pocketcore/ReplayAttackBurnMultiplier" >}}|
+|[SupportedBlockchains](#supportedblockchains)|*See description*|
+|[SessionNodeCount](#sessionnodecount)|{{< get-param "pocketcore/SessionNodeCount" >}}|
+
+**Auth Module** ([details](#auth-module))
+|Parameter|Value|
+|---|---|
+|[FeeMultipliers](#feemultipliers)|1|<!-- Hardcoding -->
+|[MaxMemoCharacters](#maxmemocharacters)|{{< get-param "auth/MaxMemoCharacters" >}}|
+|[TxSigLimit](#txsiglimit)|{{< get-param "auth/TxSigLimit" >}}|
+
+**Governance Module** ([details](#governance-module))
+|Parameter|Value|
+|---|---|
+|[ACL](#acl)|*See description*|
+|[DAOOwner](#daoowner)|{{< get-param "gov/daoOwner" >}}|
+|[Upgrade](#upgrade)|*See description*|
+
+**Off-chain parameters** ([details](#off-chain-parameters))
+|Parameter|Value|
+|---|---|
+|[ReturnOnInvestmentTarget](#returnoninvestmenttarget)|24 months|
+|[USDRelayTargetRange](#usdrelaytargetrange)|$0.00000361 per relay|
+
 
 ## Application Module
 

--- a/content/learn/protocol-parameters.md
+++ b/content/learn/protocol-parameters.md
@@ -9,17 +9,7 @@ aliases:
 description: List of all on-chain and relevant off-chain parameters that power Pocket Network.
 ---
 
-This page contains a listing of all the on-chain parameters for Pocket Network, as well as their current values.
-
-These parameters are sorted by module.
-
-* [Application Module](#application-module)
-* [PoS (Node) Module](#pos-node-module)
-* [Pocket Core Module](#pocket-core-module)
-* [Governance Module](#governance-module)
-* [Auth Module](#auth-module)
-* [Off-chain parameters](#off-chain-parameters)
-
+This page contains a listing of all the on-chain parameters for Pocket Network and their current values, as well as some relevant off-chain parameters.
 
 
 ## Application Module
@@ -28,19 +18,19 @@ These parameters control [staked applications](/learn/economics/apps) on the net
 
 ### ApplicationStakeMinimum
 
-**Current Value:** 1000000
+**Current Value:** {{< get-param "application/ApplicationStakeMinimum" >}}
 
 The minimum stake required of an app, denominated in [StakeDenom](#stakedenom). This does not have the same economic security requirements as a node's [minimum stake](#stakeminimum) because an app's access to the network (relay throughput) is already proportional to the stake.
 
 ### AppUnstakingTime
 
-**Current Value:** 1814000000000000
+**Current Value:** {{< get-param "application/AppUnstakingTime" >}}
 
 The time, in nanoseconds, that an app must wait after initiating an unstake before they can use the POKT for anything else.
 
 ### BaseRelaysPerPOKT
 
-**Current Value:** 200000
+**Current Value:** {{< get-param "application/BaseRelaysPerPOKT" >}}
 
 The number of relays that an app is entitled to for every POKT it stakes, multiplied by 100.
 
@@ -48,19 +38,19 @@ For example, if this parameter is `200000` then the throughput that apps are ent
 
 ### MaxApplications
 
-**Current Value:** 2295
+**Current Value:** {{< get-param "application/MaxApplications" >}}
 
 The number of staked applications that the protocol allows.
 
 ### MaximumChains
 
-**Current Value:** 15
+**Current Value:** {{< get-param "application/MaximumChains" >}}
 
 An app can only be configured for up to this many chains on one stake.
 
 ### ParticipationRateOn
 
-**Current Value:** false
+**Current Value:** {{< get-param "application/ParticipationRateOn" >}}
 
 The protocol may adjust an application's `MaxRelays` at the time of staking according to network-wide stake rates.
 
@@ -70,7 +60,7 @@ The `ParticipationRate` is not currently implemented, and as such, `Particiapati
 
 ### StabilityAdjustment
 
-**Current Value:** 0
+**Current Value:** {{< get-param "application/StabilityAdjustment" >}}
 
 The DAO may manually adjust an application's `MaxRelays` at the time of staking to correct for short-term fluctuations in the price of POKT. When this parameter is set to `0`, no adjustment is being made.
 
@@ -81,37 +71,37 @@ These parameters relate to [staked nodes](/learn/economics/nodes) on the networ,
 
 ### BlocksPerSession
 
-**Current Value:** 4
+**Current Value:** {{< get-param "pos/BlocksPerSession" >}}
 
 The number of blocks allowed before a Session tumbles.
 
 ### DAOAllocation
 
-**Current Value:** 10
+**Current Value:** {{< get-param "pos/DAOAllocation" >}}
 
 The DAO treasury earns this proportion of the total POKT block reward. Value is a percentage. See also [ProposerPercentage](#proposerpercentage) for another beneficiary of the block reward.
 
 ### DowntimeJailDuration
 
-**Current Value:** 3600000000000
+**Current Value:** {{< get-param "pos/DowntimeJailDuration" >}}
 
 The amount of time (in nanoseconds) before a node can unjail and resume service.
 
 ### MaxEvidenceAge
 
-**Current Value:** 120000000000
+**Current Value:** {{< get-param "pos/MaxEvidenceAge" >}}
 
 The amount of time (in nanoseconds) a node has to submit their Tendermint evidence in memory before it expires.
 
 ### MaximumChains
 
-**Current Value:** 15
+**Current Value:** {{< get-param "pos/MaximumChains" >}}
 
 A node can only be configured for up to this many chains on one stake.
 
 ### MaxJailedBlocks
 
-**Current Value:** 37960
+**Current Value:** {{< get-param "pos/MaxJailedBlocks" >}}
 
 The amount of time (in blocks) a node has to unjail before being force unstaked and slashed.
 
@@ -121,13 +111,13 @@ Warning: Reaching `MaxJailedBlocks` will result in a node's entire stake being s
 
 ### MaxValidators
 
-**Current Value:** 1000
+**Current Value:** {{< get-param "pos/MaxValidators" >}}
 
 The number of staked nodes that are eligible to be selected for producing blocks. Any staked nodes outside of the top `MaxValidators` staked validators will still be eligible to service relays.
 
 ### MinSignedPerWindow
 
-**Current Value:** 0.6
+**Current Value:** {{< get-param "pos/MinSignedPerWindow" >}}
 
 The minimum proportion of the [SignedBlocksWindow](#signedblockswindow) that a node must sign to stay out of jail.
 
@@ -137,13 +127,13 @@ If SignedBlocksWindow is 10 and MinSignedPerWindow is 0.6, this means a node can
 
 ### ProposerPercentage
 
-**Current Value:** 5
+**Current Value:** {{< get-param  "pos/ProposerPercentage" >}}
 
 Block proposers earn this proportion of the total POKT block reward. Value is a percentage. See also [DAOAllocation](#daoallocation) for another beneficiary of the block reward.
 
 ### RelaysToTokensMultiplier
 
-**Current Value:** 730
+**Current Value:** {{< get-param "pos/RelaysToTokensMultiplier" >}}
 
 The amount of POKT, denominated in [StakeDenom](#stakedenom), that is minted as block rewards per relay.
 
@@ -151,7 +141,7 @@ Note that this value will change over time. Please see the section on [POKT infl
 
 ### ServicerStakeFloorMultiplier
 
-**Current Value:** 15000000000
+**Current Value:** {{< get-param "pos/ServicerStakeFloorMultiplier" >}}
 
 The "width" of a bin (in uPOKT) used when organizing nodes for [Stake-Weighted Servicer Rewards](/learn/economics/nodes/#stake-weighted-servicer-rewards).
 
@@ -159,7 +149,7 @@ All nodes with an amount of POKT staked that is both greater than the [StakeMini
 
 ### ServicerStakeFloorMultiplierExponent
 
-**Current Value:** 1
+**Current Value:** {{< get-param "pos/ServicerStakeFloorMultiplierExponent" >}}
 
 Determines how rewards scale for each bin used when organizing nodes for [Stake-Weighted Servicer Rewards](/learn/economics/nodes/#stake-weighted-servicer-rewards). 
 
@@ -167,13 +157,13 @@ A value of 1 will cause the reward multiplier of the bins to scale linearly. Val
 
 ### ServicerStakeWeightCeiling
 
-**Current Value:** 60000000000
+**Current Value:** {{< get-param "pos/ServicerStakeWeightCeiling" >}}
 
 Denotes the minimum value (in uPOKT) of the top bin, used when organizing nodes for [Stake-Weighted Servicer Rewards](/learn/economics/nodes/#stake-weighted-servicer-rewards). Any node with an amount of staked POKT at or above this value will have the highest available reward multiplier. Staking any more POKT will not incur any greater rewards (except as a Validator).
 
 ### ServicerStakeWeightMultiplier
 
-**Current Value:** 1.92
+**Current Value:** {{< get-param "pos/ServicerStakeWeightMultiplier" >}}
 
 Offsets the increased reward emissions generated due to [Stake-Weighted Servicer Rewards](/learn/economics/nodes/#stake-weighted-servicer-rewards).
 
@@ -183,7 +173,7 @@ This parameter will likely change often due to its role in managing inflation.
 
 ### SignedBlocksWindow
 
-**Current Value:** 10
+**Current Value:** {{< get-param "pos/SignedBlocksWindow" >}}
 
 The number of consecutive blocks within which the [MinSignedPerWindow](#minsignedperwindow) proportion of blocks must be signed by a node to stay out of jail.
 
@@ -193,31 +183,31 @@ If SignedBlocksWindow is 10 and MinSignedPerWindow is 0.6, this means a node can
 
 ### SlashFractionDoubleSign
 
-**Current Value:** 0.000001
+**Current Value:** {{< get-param "pos/SlashFractionDoubleSign" >}}
 
 The % of a node's stake that is burned for double signing, where 1 is 100%.
 
 ### SlashFractionDowntime
 
-**Current Value:** 0.000001
+**Current Value:** {{< get-param "pos/SlashFractionDowntime" >}}
 
 The % of a node's stake that is burned for downtime, where 1 is 100%.
 
 ### StakeDenom
 
-**Current Value:** upokt
+**Current Value:** {{< get-param "pos/StakeDenom" >}}
 
 POKT amounts are defined by the protocol. Read more about [POKT denominations](/learn/economics/token/#POKT-denominations).
 
 ### StakeMinimum
 
-**Current Value:** 15000000000
+**Current Value:** {{< get-param "pos/StakeMinimum" >}}
 
 The minimum stake required of a node, denominated in [StakeDenom](#stakedenom), for the economic security of the protocol.
 
 ### UnstakingTime
 
-**Current Value:** 1814000000000000
+**Current Value:** {{< get-param "pos/UnstakingTime" >}}
 
 The time, in nanoseconds, that a node must wait after initiating an unstake before they can use the POKT for anything else.
 
@@ -228,31 +218,31 @@ These parameters control the logic that has to do with how the proof and claim c
 
 ### ClaimExpiration
 
-**Current Value:** 24
+**Current Value:** {{< get-param "pocketcore/ClaimExpiration" >}}
 
 The amount of time (in blocks) a node has to submit a proof for an already existing claim.
 
 ### ClaimSubmissionWindow
 
-**Current Value:** 3
+**Current Value:** {{< get-param "pocketcore/ClaimSubmissionWindow" >}}
 
 The window of time (in Sessions) a node can submit a claimTx for RelayEvidence collected in the most recently ended session, before the claimTx expires. In addition, it is also the minimum amount of time a node must wait to submit a proof for an existing claim.
 
 ### MinimumNumberOfProofs
 
-**Current Value:** 10
+**Current Value:** {{< get-param "pocketcore/MinimumNumberOfProofs" >}}
 
 The minimum number of relays a node must have for a claim and proof to be payable.
 
 ### ReplayAttackBurnMultiplier
 
-**Current Value:** 3
+**Current Value:** {{< get-param "pocketcore/ReplayAttackBurnMultiplier" >}}
 
 The multiplier slash factor for submitting a replay attack. The base slash is directly proportional to the amount of relays claimed.
 
 ### SessionNodeCount
 
-**Current Value:** 24
+**Current Value:** {{< get-param "pocketcore/SessionNodeCount" >}}
 
 The number of nodes an app will be matched with in a session.
 
@@ -265,21 +255,21 @@ List of the RelayChainIDs for all of the [supported blockchains](/supported-bloc
 
 These parameters control how transactions are constructed.
 
-### FeeMultiplier
+### FeeMultipliers
 
-**Current Value:** 1
+**Current Value:** 1 <!-- Hardcoding because of nonstandard format -->
 
 The multiplier factor for each transaction type. The base transaction fee is universally set at 10,000 uPOKT.
 
 ### MaxMemoCharacters
 
-**Current Value:** 75
+**Current Value:** {{< get-param "auth/MaxMemoCharacters" >}}
 
 The character limit of transaction memos.
 
 ### TxSigLimit
 
-**Current Value:** 8
+**Current Value:** {{< get-param "auth/TxSigLimit" >}}
 
 The maximum number of signatures that a multi-sig account can have.
 
@@ -294,7 +284,7 @@ Access control list for updating the on-chain parameters. Currently all paramete
 
 ### DAOOwner
 
-**Current Value:** a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4
+**Current Value:** {{< get-param "gov/daoOwner" >}}
 
 The account which has the permission to submit governance transactions on behalf of the DAO.
 
@@ -323,14 +313,14 @@ An object describing the details of a protocol upgrade, consisting of the follow
 
 These parameters are not on-chain, but are relevant off-chain values that are targeted by the Pocket DAO.
 
-### USDRelayTargetRange
-
-**Current Value:** $0.00000361 per relay
-
-The target price per relay after a certain amount of usage (equal to the [`ReturnOnInvestmentTarget`](#returnoninvestmenttarget). After usage for this amount of time, your cost per relay will equal this amount. This parameter is set by the DAO.
-
 ### ReturnOnInvestmentTarget
 
 **Current Value:** 24 months
 
 The desired time it takes for the [`USDRelayTargetRange`](#usdrelaytargetrange) price to be achieved, since the cost basis of a relay decreases over the lifetime of an app stake.
+
+### USDRelayTargetRange
+
+**Current Value:** $0.00000361 per relay
+
+The target price per relay after a certain amount of usage (equal to the [`ReturnOnInvestmentTarget`](#returnoninvestmenttarget). After usage for this amount of time, your cost per relay will equal this amount. This parameter is set by the DAO.

--- a/layouts/shortcodes/get-param.html
+++ b/layouts/shortcodes/get-param.html
@@ -1,0 +1,39 @@
+<!-- This shortcode takes a protocol parameter as an argument and returns its current on-chain value -->
+
+<!-- Using Portal ID from Sales -->
+{{ $postResponse := resources.GetRemote "https://mainnet.gateway.pokt.network/v1/lb/73b7b4e8bcf5e5a930dbe40a/v1/query/allParams"  (dict
+    "method" "post"
+    "body" `{"height": 0}`
+    "headers" (dict
+        "Content-Type" "application/json"
+    )
+) | transform.Unmarshal }}
+
+<!-- Read argument passed into the shortcode -->
+{{$param := .Get 0 }}
+
+<!-- Scratch var for access outside of range loops -->
+{{ $scr := newScratch }}
+
+{{ range $elemGroup := $postResponse }}
+
+  {{ range $elemVals := $elemGroup }}
+
+    {{ range $key, $value := $elemVals }}
+
+      {{ if eq ($scr.Get "nextval") "1" }} <!-- Did we previously find the param we were looking for? -->
+        {{ $value }}
+        {{ $scr.Set "nextval" "0" }} <!-- Zero out that flag now that we displayed the param -->
+      {{ end }}
+
+      {{ if eq $value $param }}
+        {{ $scr.Set "nextval" "1" }} <!-- Setting a flag to output the next value we find -->
+      {{ end }}
+
+    {{ end }}
+
+  {{ end }}
+
+{{ end }}
+
+


### PR DESCRIPTION
Prior to this PR, any time a protocol parameter is updated (inflation updates, Stake Weighted Servicer Rewards changes, etc.), we would need to update the values in the docs manually.

This PR adds a shortcode which connects to the Pocket chain via a Portal endpoint during the build process and returns the value of a specific parameter. The Protocol Parameters page has been edited to call this shortcode in place of hardcoded values.

In a few places, the parameter value was left hardcoded due to non-standard formats, but these parameters are rarely updated, so the administrative burden will remain small.